### PR TITLE
fix: add basic auth headers for non-production environments

### DIFF
--- a/includes/Blocks/SharedBlock.php
+++ b/includes/Blocks/SharedBlock.php
@@ -290,12 +290,11 @@ final class SharedBlock {
 
 		// Prepare request arguments
 		$request_args = [];
-		
 		// Add authentication headers if in non-production environment and credentials are defined
 		if ( defined( 'MULTISITE_BLOCKS_AUTH_USER' ) && defined( 'MULTISITE_BLOCKS_AUTH_PWD' ) && ! empty( MULTISITE_BLOCKS_AUTH_USER ) && ! empty( MULTISITE_BLOCKS_AUTH_PWD ) ) {
 			$request_args = [
 				'headers' => [
-					'Authorization' => 'Basic ' . base64_encode( MULTISITE_BLOCKS_AUTH_USER . ':' . MULTISITE_BLOCKS_AUTH_PWD ),
+					'Authorization' => 'Basic ' . base64_encode( MULTISITE_BLOCKS_AUTH_USER . ':' . MULTISITE_BLOCKS_AUTH_PWD ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				],
 			];
 		}

--- a/includes/Blocks/SharedBlock.php
+++ b/includes/Blocks/SharedBlock.php
@@ -288,7 +288,21 @@ final class SharedBlock {
 			sprintf( '/multisite-shared-blocks/v1/renderer/%d/%s', $post_id, $block_id )
 		);
 
-		$response = wp_safe_remote_get( $rest_url );
+		// Prepare request arguments
+		$request_args = [];
+		
+		// Add authentication headers if in non-production environment and credentials are defined
+		if ( defined( 'WP_ENV' ) && 'production' !== WP_ENV && defined( 'MULTISITE_BLOCKS_AUTH_USER' ) && defined( 'MULTISITE_BLOCKS_AUTH_PWD' ) && ! empty( MULTISITE_BLOCKS_AUTH_USER ) && ! empty( MULTISITE_BLOCKS_AUTH_PWD ) ) {
+			$request_args = [
+				'headers' => [
+					'Authorization' => 'Basic ' . base64_encode( MULTISITE_BLOCKS_AUTH_USER . ':' . MULTISITE_BLOCKS_AUTH_PWD ),
+				],
+			];
+		}
+
+		// Make the request with authentication if available
+		$response = wp_safe_remote_get( $rest_url, $request_args );
+
 		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return $block_data;
 		}

--- a/includes/Blocks/SharedBlock.php
+++ b/includes/Blocks/SharedBlock.php
@@ -292,7 +292,7 @@ final class SharedBlock {
 		$request_args = [];
 		
 		// Add authentication headers if in non-production environment and credentials are defined
-		if ( defined( 'WP_ENV' ) && 'production' !== WP_ENV && defined( 'MULTISITE_BLOCKS_AUTH_USER' ) && defined( 'MULTISITE_BLOCKS_AUTH_PWD' ) && ! empty( MULTISITE_BLOCKS_AUTH_USER ) && ! empty( MULTISITE_BLOCKS_AUTH_PWD ) ) {
+		if ( defined( 'MULTISITE_BLOCKS_AUTH_USER' ) && defined( 'MULTISITE_BLOCKS_AUTH_PWD' ) && ! empty( MULTISITE_BLOCKS_AUTH_USER ) && ! empty( MULTISITE_BLOCKS_AUTH_PWD ) ) {
 			$request_args = [
 				'headers' => [
 					'Authorization' => 'Basic ' . base64_encode( MULTISITE_BLOCKS_AUTH_USER . ':' . MULTISITE_BLOCKS_AUTH_PWD ),


### PR DESCRIPTION
## Description
Ajout de l'authentification Basic pour les requêtes multisite blocks en environnements non-production.

## Configuration requise
Lors de la mise à jour du plugin, il faudra ajouter les clés suivantes :
- `MULTISITE_BLOCKS_AUTH_USER`
- `MULTISITE_BLOCKS_AUTH_PWD`

### Fichiers à modifier :
1. `.env` - Ajouter les variables avec les valeurs appropriées
2. `config/application.php` - Définir les constantes si nécessaire